### PR TITLE
Fix storage monitor layout to use side-by-side display instead of flo…

### DIFF
--- a/demo/dev-with-storage-monitor.html
+++ b/demo/dev-with-storage-monitor.html
@@ -8,11 +8,24 @@
   <title>Development Demo with Storage Monitor</title>
   <style>
     body {
+      margin: 0;
+      padding: 0;
       font-family: Arial, sans-serif;
-      max-width: 1000px;
-      margin: 2rem auto;
-      padding: 0 1rem;
       line-height: 1.6;
+      display: flex;
+      height: 100vh;
+      overflow: hidden;
+    }
+
+    #main-content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 2rem;
+      max-width: calc(100vw - 400px);
+    }
+
+    qd-storage-monitor {
+      flex-shrink: 0;
     }
     table {
       width: 100%;
@@ -46,7 +59,8 @@
   </style>
 </head>
 <body>
-  <h1>Development Demo with Storage Monitor</h1>
+  <div id="main-content">
+    <h1>Development Demo with Storage Monitor</h1>
 
   <div class="dev-info">
     <strong>🔧 Development Mode Active</strong>
@@ -121,5 +135,6 @@
     console.log('Development demo loaded with storage monitor enabled');
     console.log('Press Ctrl+Shift+D to toggle the storage monitor');
   </script>
+  </div>
 </body>
 </html>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,7 @@ export default tseslint.config(
       'specs/**',
       'playwright-report/**',
       'test-results/**',
+      'dita/**',
     ],
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@storybook/web-components": "^7.6.0",
         "@storybook/web-components-vite": "^7.6.0",
         "@testing-library/dom": "^10.4.1",
+        "@types/jsdom": "^27.0.0",
         "chromatic": "^13.3.3",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
@@ -6078,6 +6079,44 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -6219,6 +6258,13 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@storybook/web-components": "^7.6.0",
     "@storybook/web-components-vite": "^7.6.0",
     "@testing-library/dom": "^10.4.1",
+    "@types/jsdom": "^27.0.0",
     "chromatic": "^13.3.3",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",

--- a/src/components/qd-storage-monitor.ts
+++ b/src/components/qd-storage-monitor.ts
@@ -458,12 +458,9 @@ export class StorageMonitor extends LitElement {
 
   static styles = css`
     :host {
-      position: fixed;
-      top: 0;
-      right: 0;
+      display: block;
       width: 400px;
       height: 100vh;
-      z-index: 10000;
       font-family: monospace;
       font-size: 12px;
     }


### PR DESCRIPTION
…ating overlay

Changes:
- Modified qd-storage-monitor component to use block positioning instead of fixed positioning
- Updated demo/dev-with-storage-monitor.html to use flexbox layout with main content on left and storage monitor on right
- Added @types/jsdom dev dependency for proper TypeScript support
- Added dita/ directory to eslint ignore patterns to exclude external DITA template files

The storage monitor now occupies the right-hand side of the window (400px fixed width) while the main content takes up the remaining space, allowing users to see and interact with all page content without the monitor obscuring any elements.