### PR TITLE
Fix issue 67 in BrowserTest repository

### DIFF
--- a/src/components/qd-status.ts
+++ b/src/components/qd-status.ts
@@ -50,6 +50,18 @@ export class QdStatus extends LitElement {
   @state()
   private statusColor: 'red' | 'amber' | 'green' = 'red';
 
+  /**
+   * Student name
+   */
+  @state()
+  private name = '';
+
+  /**
+   * Service ID (last 4 digits displayed)
+   */
+  @state()
+  private serviceId = '';
+
   static styles = css`
     :host {
       display: none; /* Hidden by default, shown when logged in */
@@ -65,12 +77,35 @@ export class QdStatus extends LitElement {
 
     .status-panel {
       display: flex;
-      align-items: center;
-      gap: 8px;
+      flex-direction: column;
+      gap: 4px;
       padding: 6px 12px;
       background: #fff;
       border: 1px solid #ddd;
       border-radius: 4px;
+    }
+
+    .top-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .bottom-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .user-info {
+      font-size: 13px;
+      color: #333;
+      white-space: nowrap;
+    }
+
+    .user-label {
+      font-weight: 500;
+      color: #555;
     }
 
     .status-indicator {
@@ -142,13 +177,23 @@ export class QdStatus extends LitElement {
   }
 
   render() {
+    const last4 = this.serviceId.slice(-4);
     return html`
       <div class="status-panel">
-        <div class="status-indicator ${this.statusColor}"></div>
-        <div class="progress-label">Progress:</div>
-        <div class="progress-text">${this.correct}/${this.total} Correct (${this.percentage}%)</div>
-        <button class="logout-button" @click=${() => this.handleLogout()}>Logout</button>
-        <qd-build-info></qd-build-info>
+        <div class="top-row">
+          <span class="user-info">
+            <span class="user-label">Test progress:</span>
+            ${this.name} **${last4}
+          </span>
+          <button class="logout-button" @click=${() => this.handleLogout()}>Logout</button>
+          <qd-build-info></qd-build-info>
+        </div>
+        <div class="bottom-row">
+          <div class="status-indicator ${this.statusColor}"></div>
+          <div class="progress-text">
+            ${this.correct}/${this.total} Correct (${this.percentage}%)
+          </div>
+        </div>
       </div>
     `;
   }
@@ -157,6 +202,16 @@ export class QdStatus extends LitElement {
    * Load cache from storage and update state
    */
   private loadCache() {
+    // Load session data for name/serviceId
+    const session = getJSON<SessionData>(STORAGE_KEYS.SESSION);
+    if (session) {
+      this.name = session.name || '';
+      this.serviceId = session.serviceId || '';
+    } else {
+      this.name = '';
+      this.serviceId = '';
+    }
+
     const cache = getJSON<SessionCache>(STORAGE_KEYS.CACHE);
     if (!cache) {
       this.total = 0;

--- a/tests/unit/qd-status.test.ts
+++ b/tests/unit/qd-status.test.ts
@@ -41,6 +41,14 @@ describe('QdStatus Component', () => {
     });
 
     it('should display session info when cache exists', async () => {
+      // Set up session data
+      setJSON(STORAGE_KEYS.SESSION, {
+        serviceId: 'RN2344',
+        name: 'MAYO',
+        release: 'Test Release',
+        lastActivity: Date.now(),
+      });
+
       // Set up session cache
       const cache: SessionCache = {
         totals: { total: 10, answered: 10, correct: 8 },
@@ -59,6 +67,31 @@ describe('QdStatus Component', () => {
       const shadow = element.shadowRoot;
       expect(shadow?.textContent).toContain('8/10 Correct');
       expect(shadow?.textContent).toContain('80%');
+      // Check username display
+      expect(shadow?.textContent).toContain('MAYO');
+      expect(shadow?.textContent).toContain('**2344');
+    });
+
+    it('should display username and last 4 digits of serviceId', async () => {
+      // Set up session data
+      setJSON(STORAGE_KEYS.SESSION, {
+        serviceId: 'AB123456',
+        name: 'TestUser',
+        release: 'Test Release',
+        lastActivity: Date.now(),
+      });
+
+      // Trigger cache reload
+      const event = new CustomEvent('qd:state-changed');
+      document.dispatchEvent(event);
+
+      element.requestUpdate();
+      await element.updateComplete;
+
+      const shadow = element.shadowRoot;
+      expect(shadow?.textContent).toContain('TestUser');
+      expect(shadow?.textContent).toContain('**3456');
+      expect(shadow?.textContent).toContain('Test progress:');
     });
 
     it('should calculate and display percentage', async () => {


### PR DESCRIPTION
Display user identity in qd-status component:
- Top row: "Test progress: NAME **XXXX [Logout]" with name and last 4 digits of serviceId
- Bottom row: Status indicator and progress stats

Fixes #67