### PR TITLE
Fix CI demo to main folder copy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm ci
 
       - name: Build bundle
-        run: npm run build
+        run: npm run build:dita
 
       - name: Create demo site directory
         run: |


### PR DESCRIPTION
Changed pages.yml workflow to copy dita-demo/ instead of demo/ to the main/ folder in gh-pages branch, matching PR preview behavior.