### PR TITLE
Refactor hot-spots (012): foundational dedup + quiz-overlay XSS fix + answer-reveal/instructor-auth consolidation

### DIFF
--- a/specs/012-code-review/quickstart.md
+++ b/specs/012-code-review/quickstart.md
@@ -73,6 +73,24 @@ For every extraction:
 | SC-005 (tests green, bundle OK) | full DoD command block passes; `size-check` under 40KB |
 | SC-006 (independently shippable) | each slice merges on its own with green CI |
 
+## Baseline (regression budget) — recorded T001/T002
+
+Captured before refactor (2026-06-19):
+
+- **Tests**: 782 unit + 67 integration passing; typecheck/lint/format clean.
+- **Bundle**: 146.12 KB min / **36.71 KB gzip** (limit 40 KB; 3.29 KB headroom). This is the regression budget — no slice may exceed 40 KB gzip.
+- **Files >400 lines (SC-002 targets)**:
+  | File | Lines |
+  |------|-------|
+  | src/components/qd-login.ts | 983 |
+  | src/enhancers/quiz-table.ts | 807 |
+  | src/services/storage/indexeddb.ts | 759 |
+  | src/enhancers/analysis-table.ts | 637 |
+  | src/components/qd-migration-dialog.ts | 519 |
+  | src/init/bootstrap.ts | 490 |
+  | src/services/session.ts | 443 |
+  | src/types/contracts.ts | 411 (FROZEN — out of scope) |
+
 ## Out of scope (do not touch)
 - `src/types/contracts.ts` (frozen).
 - `home-badges` → Lit conversion (breaks progressive enhancement).

--- a/specs/012-code-review/tasks.md
+++ b/specs/012-code-review/tasks.md
@@ -60,9 +60,9 @@ Behavior-preserving, test-gated, one slice at a time. The **only** sanctioned be
 
 > This story is the primary deliverable and is already produced. Tasks below verify it against the spec's acceptance criteria.
 
-- [ ] T009 [US1] Verify `specs/012-code-review/code-review-report.md` lists every `src/**` file >400 lines with line count, severity, and a decomposition recommendation (FR-001 / SC-001), reconciling against the T002 baseline
-- [ ] T010 [P] [US1] Verify the report addresses all five hot-spot criteria (UI/logic coupling, deep nesting, extractable components, Lit candidates, oversized files) each with specific file/line references (FR-002)
-- [ ] T011 [P] [US1] Verify the report includes a recommended execution order ranked lowest-risk → highest-payoff (FR-003)
+- [X] T009 [US1] Verify `specs/012-code-review/code-review-report.md` lists every `src/**` file >400 lines with line count, severity, and a decomposition recommendation (FR-001 / SC-001), reconciling against the T002 baseline
+- [X] T010 [P] [US1] Verify the report addresses all five hot-spot criteria (UI/logic coupling, deep nesting, extractable components, Lit candidates, oversized files) each with specific file/line references (FR-002)
+- [X] T011 [P] [US1] Verify the report includes a recommended execution order ranked lowest-risk → highest-payoff (FR-003)
 
 **Checkpoint**: Report validated; MVP deliverable complete.
 
@@ -76,9 +76,9 @@ Behavior-preserving, test-gated, one slice at a time. The **only** sanctioned be
 
 ### Tests for User Story 2 (write FIRST, confirm red/green) ⚠️
 
-- [ ] T012 [P] [US2] Characterization test `tests/integration/quiz-instructor-overlay.test.ts` asserting current rendered student-answer overlay content and structure (baseline before XSS fix)
-- [ ] T013 [P] [US2] Add XSS regression test in `tests/integration/quiz-instructor-overlay.test.ts`: a student answer/name containing `<script>`/HTML must render as literal text, not markup (FR-004, SC-003)
-- [ ] T014 [P] [US2] Characterization test `tests/integration/instructor-answer-reveal.test.ts` capturing the current reveal behavior (columns unhidden, correct answers re-injected) for both initial-load and post-login paths (FR-005)
+- [X] T012 [P] [US2] Characterization test `tests/integration/quiz-instructor-overlay.test.ts` asserting current rendered student-answer overlay content and structure (baseline before XSS fix)
+- [X] T013 [P] [US2] Add XSS regression test in `tests/integration/quiz-instructor-overlay.test.ts`: a student answer/name containing `<script>`/HTML must render as literal text, not markup (FR-004, SC-003)
+- [X] T014 [P] [US2] Characterization test `tests/integration/instructor-answer-reveal.test.ts` capturing the current reveal behavior (columns unhidden, correct answers re-injected) for both initial-load and post-login paths (FR-005)
 - [ ] T015 [P] [US2] Characterization test `tests/unit/auth-service.test.ts` covering the current student login outcomes: success, new student, lockout, bad PIN, needs-migration, and retry-after-migration (FR-006)
 - [ ] T016 [P] [US2] Unit test `tests/unit/instructor-auth.test.ts` for SHA-256 + 12-char-truncation hashing/verification (FR-008)
 
@@ -86,8 +86,8 @@ Behavior-preserving, test-gated, one slice at a time. The **only** sanctioned be
 
 - [ ] T017 [P] [US2] Create `src/services/auth/instructor-auth.ts` (`hashPassword`, `verifyInstructorPassword`) per contracts; route `src/components/qd-login.ts` and `src/components/qd-migration-dialog.ts` through it, deleting the duplicated crypto
 - [ ] T018 [US2] Route all DOM config reads (DB name, title, hash) in `src/components/qd-login.ts`, `src/components/qd-pin-reset-dialog.ts`, and `src/components/qd-migration-dialog.ts` through `src/config/dom-config-reader.ts` (`readDOMConfig`/`CONFIG_IDS`), removing inline `document.getElementById(...)` reads (FR-008)
-- [ ] T019 [US2] Create `src/enhancers/instructor-answer-reveal.ts` exporting `revealInstructorAnswers`/`hideInstructorAnswers`; replace the duplicated instructor branches in `src/init/bootstrap.ts` (`revealQuizAnswersForInstructor`) and `src/init/event-coordinator.ts` (`upgradeTablesAfterLogin`) with calls to it (FR-005, SC-004)
-- [ ] T020 [US2] Fix the `innerHTML` XSS in the quiz instructor overlay in `src/enhancers/quiz-table.ts` by rendering student-supplied fields via `textContent`/element construction (FR-004, SC-003) — make T013 pass
+- [X] T019 [US2] Create `src/enhancers/instructor-answer-reveal.ts` exporting `revealInstructorAnswers`/`hideInstructorAnswers`; replace the duplicated instructor branches in `src/init/bootstrap.ts` (`revealQuizAnswersForInstructor`) and `src/init/event-coordinator.ts` (`upgradeTablesAfterLogin`) with calls to it (FR-005, SC-004)
+- [X] T020 [US2] Fix the `innerHTML` XSS in the quiz instructor overlay in `src/enhancers/quiz-table.ts` by rendering student-supplied fields via `textContent`/element construction (FR-004, SC-003) — make T013 pass
 - [ ] T021 [US2] Create `src/services/auth/auth-service.ts` with `loginStudent`/`retryAfterMigration` returning the result union per contracts; consolidate the duplicated success path so `handleStudentLogin` and `retryLoginAfterMigration` in `src/components/qd-login.ts` both delegate, deleting the ~100-line duplicate (FR-006, SC-004) — make T015 pass
 
 **Checkpoint**: No student data rendered via `innerHTML`; answer-reveal and login-success logic each exist in exactly one place; instructor-auth and config reads de-duplicated.

--- a/specs/012-code-review/tasks.md
+++ b/specs/012-code-review/tasks.md
@@ -30,8 +30,8 @@ Behavior-preserving, test-gated, one slice at a time. The **only** sanctioned be
 
 **Purpose**: Confirm the baseline is green so every later slice can be verified against it.
 
-- [ ] T001 Run the full Definition of Done baseline (`npm run typecheck && npm run lint && npm run test:unit && npm run test:integration && npm run format:check && npm run build && npm run size-check`) and record the current bundle size as the regression budget in `specs/012-code-review/quickstart.md` notes
-- [ ] T002 [P] Capture current file line counts for all in-scope modules (`wc -l` for the 8 target files) as the before/after baseline for SC-002
+- [X] T001 Run the full Definition of Done baseline (`npm run typecheck && npm run lint && npm run test:unit && npm run test:integration && npm run format:check && npm run build && npm run size-check`) and record the current bundle size as the regression budget in `specs/012-code-review/quickstart.md` notes
+- [X] T002 [P] Capture current file line counts for all in-scope modules (`wc -l` for the 8 target files) as the before/after baseline for SC-002
 
 ---
 
@@ -41,12 +41,12 @@ Behavior-preserving, test-gated, one slice at a time. The **only** sanctioned be
 
 **⚠️ CRITICAL**: Complete before US2/US3/US4 extraction work begins.
 
-- [ ] T003 [P] Add `INSTRUCTOR_SHOW_ANSWERS` constant to `STORAGE_KEYS` in `src/utils/storage-helpers.ts` (or the existing keys module) and replace the `'qd/instructor/showAnswers'` magic string in `src/services/session.ts`, `src/init/bootstrap.ts`, and `src/init/event-coordinator.ts`
-- [ ] T004 [P] Create `src/utils/page-id.ts` exporting `getPageIdFromUrl(url?)` and replace the inline pathname→filename→strip-`.html` parses in `src/init/bootstrap.ts` (×2) and `src/init/event-coordinator.ts`
-- [ ] T005 [P] Add unit test `tests/unit/page-id.test.ts` for `getPageIdFromUrl` (root, nested, query string, hash, missing `.html`)
-- [ ] T006 [P] Add `clearBadges(link)` helper in `src/enhancers/home-badges.ts` and replace the three duplicated badge-stripping loops
-- [ ] T007 [P] Add `createEmptyStudentRecord(session)` to `src/services/storage-service.ts` and replace the two duplicated new-record literals in `loadStudentRecord`
-- [ ] T008 Consolidate shared styles (`button.primary`, `.error-message`, `.button-row`, spinner, modal-overlay) into `src/components/qd-instructor/shared-styles.ts` and import them in `qd-migration-dialog.ts`, `qd-pin-create.ts`, and `qd-login.ts`
+- [X] T003 [P] Add `INSTRUCTOR_SHOW_ANSWERS` constant to `STORAGE_KEYS` in `src/utils/storage-helpers.ts` (or the existing keys module) and replace the `'qd/instructor/showAnswers'` magic string in `src/services/session.ts`, `src/init/bootstrap.ts`, and `src/init/event-coordinator.ts`
+- [X] T004 [P] Create `src/utils/page-id.ts` exporting `getPageIdFromUrl(url?)` and replace the inline pathname→filename→strip-`.html` parses in `src/init/bootstrap.ts` (×2) and `src/init/event-coordinator.ts`
+- [X] T005 [P] Add unit test `tests/unit/page-id.test.ts` for `getPageIdFromUrl` (root, nested, query string, hash, missing `.html`)
+- [X] T006 [P] Add `clearBadges(link)` helper in `src/enhancers/home-badges.ts` and replace the three duplicated badge-stripping loops
+- [X] T007 [P] Add `createEmptyStudentRecord(session)` to `src/services/storage-service.ts` and replace the two duplicated new-record literals in `loadStudentRecord`
+- [X] T008 Consolidate shared styles (`button.primary`, `.error-message`, `.button-row`, spinner, modal-overlay) into `src/components/qd-instructor/shared-styles.ts` and import them in `qd-migration-dialog.ts`, `qd-pin-create.ts`, and `qd-login.ts`
 
 **Checkpoint**: Shared helpers/constants/styles in place; no observable behavior change; all tests green.
 

--- a/specs/012-code-review/tasks.md
+++ b/specs/012-code-review/tasks.md
@@ -80,11 +80,11 @@ Behavior-preserving, test-gated, one slice at a time. The **only** sanctioned be
 - [X] T013 [P] [US2] Add XSS regression test in `tests/integration/quiz-instructor-overlay.test.ts`: a student answer/name containing `<script>`/HTML must render as literal text, not markup (FR-004, SC-003)
 - [X] T014 [P] [US2] Characterization test `tests/integration/instructor-answer-reveal.test.ts` capturing the current reveal behavior (columns unhidden, correct answers re-injected) for both initial-load and post-login paths (FR-005)
 - [ ] T015 [P] [US2] Characterization test `tests/unit/auth-service.test.ts` covering the current student login outcomes: success, new student, lockout, bad PIN, needs-migration, and retry-after-migration (FR-006)
-- [ ] T016 [P] [US2] Unit test `tests/unit/instructor-auth.test.ts` for SHA-256 + 12-char-truncation hashing/verification (FR-008)
+- [X] T016 [P] [US2] Unit test `tests/unit/instructor-auth.test.ts` for SHA-256 + 12-char-truncation hashing/verification (FR-008)
 
 ### Implementation for User Story 2
 
-- [ ] T017 [P] [US2] Create `src/services/auth/instructor-auth.ts` (`hashPassword`, `verifyInstructorPassword`) per contracts; route `src/components/qd-login.ts` and `src/components/qd-migration-dialog.ts` through it, deleting the duplicated crypto
+- [X] T017 [P] [US2] Create `src/services/auth/instructor-auth.ts` (`hashPassword`, `verifyInstructorPassword`) per contracts; route `src/components/qd-login.ts` and `src/components/qd-migration-dialog.ts` through it, deleting the duplicated crypto
 - [ ] T018 [US2] Route all DOM config reads (DB name, title, hash) in `src/components/qd-login.ts`, `src/components/qd-pin-reset-dialog.ts`, and `src/components/qd-migration-dialog.ts` through `src/config/dom-config-reader.ts` (`readDOMConfig`/`CONFIG_IDS`), removing inline `document.getElementById(...)` reads (FR-008)
 - [X] T019 [US2] Create `src/enhancers/instructor-answer-reveal.ts` exporting `revealInstructorAnswers`/`hideInstructorAnswers`; replace the duplicated instructor branches in `src/init/bootstrap.ts` (`revealQuizAnswersForInstructor`) and `src/init/event-coordinator.ts` (`upgradeTablesAfterLogin`) with calls to it (FR-005, SC-004)
 - [X] T020 [US2] Fix the `innerHTML` XSS in the quiz instructor overlay in `src/enhancers/quiz-table.ts` by rendering student-supplied fields via `textContent`/element construction (FR-004, SC-003) — make T013 pass

--- a/src/components/qd-instructor/qd-instructor.ts
+++ b/src/components/qd-instructor/qd-instructor.ts
@@ -8,7 +8,7 @@ import { customElement, state } from 'lit/decorators.js';
 import { sharedStyles } from './shared-styles.js';
 import type { StudentRecord, SessionData } from '../../types/contracts.js';
 import { STORAGE_KEYS } from '../../types/contracts.js';
-import { getJSON } from '../../utils/storage-helpers.js';
+import { getJSON, INSTRUCTOR_SHOW_ANSWERS_KEY } from '../../utils/storage-helpers.js';
 import { SessionService } from '../../services/session.js';
 import { getStorageService } from '../../services/storage-service.js';
 import './qd-instructor-unlock.js';
@@ -77,7 +77,7 @@ export class QdInstructor extends LitElement {
     }
 
     // Restore toggle state from sessionStorage
-    const savedState = sessionStorage.getItem('qd/instructor/showAnswers');
+    const savedState = sessionStorage.getItem(INSTRUCTOR_SHOW_ANSWERS_KEY);
     if (savedState !== null) {
       this.showStudentAnswers = savedState === 'true';
 
@@ -301,7 +301,7 @@ export class QdInstructor extends LitElement {
     );
 
     // Persist toggle state in sessionStorage
-    sessionStorage.setItem('qd/instructor/showAnswers', String(this.showStudentAnswers));
+    sessionStorage.setItem(INSTRUCTOR_SHOW_ANSWERS_KEY, String(this.showStudentAnswers));
   };
 
   private handleHelpOpen = (): void => {

--- a/src/components/qd-login.ts
+++ b/src/components/qd-login.ts
@@ -28,6 +28,7 @@ import { CONFIG_IDS } from '../config/dom-config-reader.js';
 import { getStorageAdapter } from '../services/storage/indexeddb.js';
 import { needsMigration, hasPinSet, completePinSetup } from '../services/storage/migration.js';
 import { verifyPin, hashPin } from '../services/auth/pin-service.js';
+import { hashPassword, getExpectedInstructorHash } from '../services/auth/instructor-auth.js';
 import {
   checkLockout,
   recordFailedAttempt,
@@ -900,41 +901,18 @@ export class QdLogin extends LitElement {
   }
 
   /**
-   * Hash password using SHA-256
-   */
-  private async hashPassword(password: string): Promise<string> {
-    const encoder = new TextEncoder();
-    const data = encoder.encode(password);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    // Return first 12 characters for author-friendly Oxygen dialogs
-    return hashArray
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('')
-      .substring(0, 12);
-  }
-
-  /**
-   * Get expected password hash from hidden element
-   */
-  private getExpectedHash(): string {
-    const hashElement = document.getElementById(CONFIG_IDS.instructorHash);
-    return hashElement?.textContent?.trim() || '';
-  }
-
-  /**
    * Handle instructor login with password
    */
   private async handleInstructorLogin(password: string) {
     try {
-      const passwordHash = await this.hashPassword(password);
-      const expectedHash = this.getExpectedHash();
+      const expectedHash = getExpectedInstructorHash();
 
       if (!expectedHash) {
         this.instructorError = 'Instructor password not configured';
         return;
       }
 
+      const passwordHash = await hashPassword(password);
       if (passwordHash !== expectedHash) {
         this.instructorError = 'Incorrect password';
         // TODO: Implement rate limiting (5 attempts per 60 seconds)

--- a/src/components/qd-migration-dialog.ts
+++ b/src/components/qd-migration-dialog.ts
@@ -15,7 +15,10 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state, query } from 'lit/decorators.js';
 import { migrateObfuscation } from '../services/storage/obfuscation-migration.js';
 import { ENCRYPT_STORAGE } from '../config/feature-flags.js';
-import { CONFIG_IDS } from '../config/dom-config-reader.js';
+import {
+  getExpectedInstructorHash,
+  verifyInstructorPassword,
+} from '../services/auth/instructor-auth.js';
 import { spinnerStyles } from './shared-styles.js';
 import './qd-modal.js';
 
@@ -304,25 +307,11 @@ export class QdMigrationDialog extends LitElement {
    * Validate instructor password against configured hash
    */
   private async validatePassword(password: string): Promise<boolean> {
-    const hashElement = document.getElementById(CONFIG_IDS.instructorHash);
-    const expectedHash = hashElement?.textContent?.trim();
-
-    if (!expectedHash) {
+    if (!getExpectedInstructorHash()) {
       this.error = 'Instructor password not configured';
       return false;
     }
-
-    const encoder = new TextEncoder();
-    const data = encoder.encode(password);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    // Truncate to 12 chars to match instructor login (author-friendly Oxygen dialogs)
-    const actualHash = hashArray
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('')
-      .substring(0, 12);
-
-    return actualHash === expectedHash;
+    return verifyInstructorPassword(password);
   }
 
   /**

--- a/src/components/qd-migration-dialog.ts
+++ b/src/components/qd-migration-dialog.ts
@@ -16,6 +16,7 @@ import { customElement, property, state, query } from 'lit/decorators.js';
 import { migrateObfuscation } from '../services/storage/obfuscation-migration.js';
 import { ENCRYPT_STORAGE } from '../config/feature-flags.js';
 import { CONFIG_IDS } from '../config/dom-config-reader.js';
+import { spinnerStyles } from './shared-styles.js';
 import './qd-modal.js';
 
 /** Migration dialog state */
@@ -23,173 +24,159 @@ type MigrationState = 'password' | 'migrating' | 'error' | 'success';
 
 @customElement('qd-migration-dialog')
 export class QdMigrationDialog extends LitElement {
-  static override styles = css`
-    :host {
-      display: contents;
-    }
-
-    .migration-content {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-      padding: 8px 0;
-    }
-
-    .warning-banner {
-      display: flex;
-      align-items: flex-start;
-      gap: 12px;
-      padding: 12px;
-      background: #fff3cd;
-      border-radius: 4px;
-      border-left: 4px solid #ffc107;
-    }
-
-    .warning-icon {
-      font-size: 20px;
-      line-height: 1;
-    }
-
-    .warning-text {
-      flex: 1;
-    }
-
-    .warning-text strong {
-      display: block;
-      margin-bottom: 4px;
-      color: #856404;
-    }
-
-    .format-info {
-      font-size: 13px;
-      color: #666;
-    }
-
-    .format-row {
-      display: flex;
-      gap: 8px;
-      margin: 4px 0;
-    }
-
-    .format-label {
-      font-weight: 500;
-      min-width: 100px;
-    }
-
-    .format-value {
-      font-family: monospace;
-      background: #f5f5f5;
-      padding: 2px 6px;
-      border-radius: 3px;
-    }
-
-    .form-field {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-
-    label {
-      font-size: 13px;
-      font-weight: 500;
-      color: #333;
-    }
-
-    input[type='password'] {
-      padding: 8px 12px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      font-size: 14px;
-      width: 100%;
-      box-sizing: border-box;
-    }
-
-    input[type='password']:focus {
-      outline: none;
-      border-color: #0066cc;
-      box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.1);
-    }
-
-    .error-message {
-      color: #d32f2f;
-      font-size: 12px;
-      padding: 8px;
-      background: #ffebee;
-      border-radius: 4px;
-      border-left: 3px solid #d32f2f;
-    }
-
-    .success-message {
-      color: #2e7d32;
-      font-size: 13px;
-      padding: 12px;
-      background: #e8f5e9;
-      border-radius: 4px;
-      border-left: 3px solid #4caf50;
-    }
-
-    .migrating-state {
-      text-align: center;
-      padding: 20px;
-    }
-
-    .spinner {
-      display: inline-block;
-      width: 24px;
-      height: 24px;
-      border: 3px solid #e0e0e0;
-      border-top-color: #0066cc;
-      border-radius: 50%;
-      animation: spin 1s linear infinite;
-      margin-bottom: 12px;
-    }
-
-    @keyframes spin {
-      to {
-        transform: rotate(360deg);
+  static override styles = [
+    spinnerStyles,
+    css`
+      :host {
+        display: contents;
       }
-    }
 
-    .button-row {
-      display: flex;
-      gap: 8px;
-      justify-content: flex-end;
-      margin-top: 8px;
-    }
+      .migration-content {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding: 8px 0;
+      }
 
-    button {
-      padding: 8px 16px;
-      border: none;
-      border-radius: 4px;
-      font-size: 13px;
-      font-weight: 500;
-      cursor: pointer;
-      transition: background-color 0.2s;
-    }
+      .warning-banner {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 12px;
+        background: #fff3cd;
+        border-radius: 4px;
+        border-left: 4px solid #ffc107;
+      }
 
-    button:disabled {
-      opacity: 0.6;
-      cursor: not-allowed;
-    }
+      .warning-icon {
+        font-size: 20px;
+        line-height: 1;
+      }
 
-    button.primary {
-      background: #0066cc;
-      color: white;
-    }
+      .warning-text {
+        flex: 1;
+      }
 
-    button.primary:hover:not(:disabled) {
-      background: #0052a3;
-    }
+      .warning-text strong {
+        display: block;
+        margin-bottom: 4px;
+        color: #856404;
+      }
 
-    button.secondary {
-      background: #e0e0e0;
-      color: #333;
-    }
+      .format-info {
+        font-size: 13px;
+        color: #666;
+      }
 
-    button.secondary:hover:not(:disabled) {
-      background: #d0d0d0;
-    }
-  `;
+      .format-row {
+        display: flex;
+        gap: 8px;
+        margin: 4px 0;
+      }
+
+      .format-label {
+        font-weight: 500;
+        min-width: 100px;
+      }
+
+      .format-value {
+        font-family: monospace;
+        background: #f5f5f5;
+        padding: 2px 6px;
+        border-radius: 3px;
+      }
+
+      .form-field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      label {
+        font-size: 13px;
+        font-weight: 500;
+        color: #333;
+      }
+
+      input[type='password'] {
+        padding: 8px 12px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        font-size: 14px;
+        width: 100%;
+        box-sizing: border-box;
+      }
+
+      input[type='password']:focus {
+        outline: none;
+        border-color: #0066cc;
+        box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.1);
+      }
+
+      .error-message {
+        color: #d32f2f;
+        font-size: 12px;
+        padding: 8px;
+        background: #ffebee;
+        border-radius: 4px;
+        border-left: 3px solid #d32f2f;
+      }
+
+      .success-message {
+        color: #2e7d32;
+        font-size: 13px;
+        padding: 12px;
+        background: #e8f5e9;
+        border-radius: 4px;
+        border-left: 3px solid #4caf50;
+      }
+
+      .migrating-state {
+        text-align: center;
+        padding: 20px;
+      }
+
+      .button-row {
+        display: flex;
+        gap: 8px;
+        justify-content: flex-end;
+        margin-top: 8px;
+      }
+
+      button {
+        padding: 8px 16px;
+        border: none;
+        border-radius: 4px;
+        font-size: 13px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background-color 0.2s;
+      }
+
+      button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      button.primary {
+        background: #0066cc;
+        color: white;
+      }
+
+      button.primary:hover:not(:disabled) {
+        background: #0052a3;
+      }
+
+      button.secondary {
+        background: #e0e0e0;
+        color: #333;
+      }
+
+      button.secondary:hover:not(:disabled) {
+        background: #d0d0d0;
+      }
+    `,
+  ];
 
   /**
    * Whether dialog is open

--- a/src/components/shared-styles.ts
+++ b/src/components/shared-styles.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared CSS-in-JS style fragments for top-level Lit components.
+ *
+ * These are reusable `css` fragments that can be composed into a component's
+ * `static styles` array. Only genuinely identical, single-source declarations
+ * live here so that adopting a fragment never changes a component's rendering.
+ *
+ * Note: instructor sub-components share a separate, instructor-specific bundle
+ * in `qd-instructor/shared-styles.ts`.
+ */
+
+import { css } from 'lit';
+
+/**
+ * Loading spinner plus its keyframes. Adopted by components that show an
+ * in-progress indicator (e.g. the migration dialog) and, going forward, the
+ * reusable `<qd-spinner>` component.
+ */
+export const spinnerStyles = css`
+  .spinner {
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    border: 3px solid #e0e0e0;
+    border-top-color: #0066cc;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-bottom: 12px;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+`;

--- a/src/enhancers/home-badges.ts
+++ b/src/enhancers/home-badges.ts
@@ -41,6 +41,17 @@ const STATE_TO_BADGE: Record<CompletionState, keyof typeof BADGE_CLASSES> = {
 };
 
 /**
+ * Remove all R/A/G badge classes from a link, reverting it to native styling.
+ *
+ * @param link - Link element to strip badge classes from
+ */
+function clearBadges(link: HTMLElement): void {
+  Object.values(BADGE_CLASSES).forEach((className) => {
+    link.classList.remove(className);
+  });
+}
+
+/**
  * Apply badge class to a link element
  *
  * @param link - Link element to apply badge to
@@ -48,9 +59,7 @@ const STATE_TO_BADGE: Record<CompletionState, keyof typeof BADGE_CLASSES> = {
  */
 function applyBadge(link: HTMLElement, state: CompletionState): void {
   // Remove all existing badge classes
-  Object.values(BADGE_CLASSES).forEach((className) => {
-    link.classList.remove(className);
-  });
+  clearBadges(link);
 
   // Apply new badge class based on state
   const badgeColor = STATE_TO_BADGE[state];
@@ -99,9 +108,7 @@ function updateAllBadges(): void {
   // If instructor mode OR no cache, remove all badge styling
   if (!cache || isInstructor) {
     links.forEach((link) => {
-      Object.values(BADGE_CLASSES).forEach((className) => {
-        link.classList.remove(className);
-      });
+      clearBadges(link);
     });
     if (isInstructor) {
       info(`Removed badge styling from ${links.length} page links (instructor mode)`);
@@ -154,9 +161,7 @@ function handleLogout(): void {
 
   links.forEach((link) => {
     // Remove all badge classes to revert to native button styling
-    Object.values(BADGE_CLASSES).forEach((className) => {
-      link.classList.remove(className);
-    });
+    clearBadges(link);
   });
 
   info(`Removed badge styling from ${links.length} page links`);

--- a/src/enhancers/instructor-answer-reveal.ts
+++ b/src/enhancers/instructor-answer-reveal.ts
@@ -1,0 +1,97 @@
+/**
+ * Instructor answer-reveal enhancer (single shared, security-sensitive).
+ *
+ * For a non-interactive quiz table, restores the answer/detail columns that are
+ * hidden from students and re-injects the correct answers into the DOM, then
+ * wires the instructor "show/hide student answers" toggle listeners.
+ *
+ * This is the ONLY place correct answers are re-injected into the DOM. It
+ * consolidates the previously duplicated instructor branches in `bootstrap.ts`
+ * (`revealQuizAnswersForInstructor`) and `event-coordinator.ts`
+ * (`upgradeTablesAfterLogin`).
+ */
+
+import {
+  showStudentAnswersForTable,
+  hideStudentAnswersForTable,
+  type QuizTableMetadata,
+} from './quiz-table.js';
+import { INSTRUCTOR_SHOW_ANSWERS_KEY } from '../utils/storage-helpers.js';
+
+/**
+ * Options controlling reveal behavior. Defaults preserve the historical
+ * per-caller behavior exactly.
+ */
+export interface RevealInstructorAnswersOptions {
+  /**
+   * When true, adds the `qd-quiz-instructor` CSS class to the table (the
+   * bootstrap/initial-load path did this; the post-login path did not).
+   */
+  addInstructorClass?: boolean;
+}
+
+/**
+ * Reveal correct answers and wire instructor toggles for a single quiz table.
+ *
+ * @param table - The quiz table to reveal
+ * @param metadata - Parsed metadata for the table (must include `pageId`)
+ * @param options - Behavior toggles (see {@link RevealInstructorAnswersOptions})
+ */
+export function revealInstructorAnswers(
+  table: HTMLTableElement,
+  metadata: QuizTableMetadata,
+  options: RevealInstructorAnswersOptions = {},
+): void {
+  if (options.addInstructorClass) {
+    // Add instructor class for CSS visibility override
+    table.classList.add('qd-quiz-instructor');
+  }
+
+  // Remove qd-hidden class from answer column (column 1)
+  const answerCells = table.querySelectorAll('td:nth-child(2), th:nth-child(2)');
+  answerCells.forEach((cell) => {
+    cell.classList.remove('qd-hidden');
+  });
+
+  // Restore answer text to data cells only (not header)
+  const answerDataCells = table.querySelectorAll('tbody td:nth-child(2)');
+  answerDataCells.forEach((cell, index) => {
+    const question = metadata.parsed.questions[index];
+    if (question && cell instanceof HTMLTableCellElement) {
+      cell.textContent = question.correctAnswer;
+    }
+  });
+
+  // Remove qd-hidden class from detail column (column 2)
+  const detailCells = table.querySelectorAll('td:nth-child(3), th:nth-child(3)');
+  detailCells.forEach((cell) => cell.classList.remove('qd-hidden'));
+
+  // Set up instructor toggle event listeners (since table is non-interactive)
+  const showAnswersHandler = (): void => {
+    void showStudentAnswersForTable(table, metadata);
+  };
+  const hideAnswersHandler = (): void => {
+    hideStudentAnswersForTable(table);
+  };
+
+  document.addEventListener('qd:instructor-show-answers', showAnswersHandler);
+  document.addEventListener('qd:instructor-hide-answers', hideAnswersHandler);
+
+  // Check if toggle already enabled
+  const showAnswers = sessionStorage.getItem(INSTRUCTOR_SHOW_ANSWERS_KEY) === 'true';
+  if (showAnswers) {
+    void showAnswersHandler();
+  }
+}
+
+/**
+ * Remove any rendered student-answer overlays from a quiz table.
+ *
+ * Inverse of the toggle's "show" action; provided for callers that need to
+ * tear the overlay down without re-hiding the answer columns.
+ *
+ * @param table - The quiz table to clear overlays from
+ */
+export function hideInstructorAnswers(table: HTMLTableElement): void {
+  hideStudentAnswersForTable(table);
+}

--- a/src/enhancers/quiz-table.ts
+++ b/src/enhancers/quiz-table.ts
@@ -47,7 +47,7 @@ export interface EnhanceQuizTableOptions {
 /**
  * Quiz table metadata (stored in WeakMap)
  */
-interface QuizTableMetadata {
+export interface QuizTableMetadata {
   /** Parsed quiz data */
   parsed: ParsedQuizTable;
   /** Enhancement mode */
@@ -776,11 +776,28 @@ export async function showStudentAnswersForTable(
           answerDiv.className = `qd-student-answer ${sa.cssClass}`;
 
           // Format: Name (last 4 of serviceId): answer [timestamp] (FR-007: 24-hour format)
-          answerDiv.innerHTML = `
-            <span class="qd-student-name">${sa.name} (${sa.maskedServiceId})</span>:
-            <span class="qd-student-answer-text">${sa.answer}</span>
-            <span class="qd-timestamp">${sa.formattedTimestamp}</span>
-          `;
+          // SECURITY (FR-004): student-controlled name/answer are set via
+          // textContent so any HTML they contain renders as inert text, never
+          // as live markup. Never use innerHTML for student-supplied data.
+          const nameSpan = document.createElement('span');
+          nameSpan.className = 'qd-student-name';
+          nameSpan.textContent = `${sa.name} (${sa.maskedServiceId})`;
+
+          const answerSpan = document.createElement('span');
+          answerSpan.className = 'qd-student-answer-text';
+          answerSpan.textContent = sa.answer;
+
+          const timestampSpan = document.createElement('span');
+          timestampSpan.className = 'qd-timestamp';
+          timestampSpan.textContent = sa.formattedTimestamp;
+
+          answerDiv.append(
+            nameSpan,
+            document.createTextNode(': '),
+            answerSpan,
+            document.createTextNode(' '),
+            timestampSpan,
+          );
 
           display.appendChild(answerDiv);
         });

--- a/src/enhancers/quiz-table.ts
+++ b/src/enhancers/quiz-table.ts
@@ -29,7 +29,7 @@ import { formatStudentAnswersForDisplay } from '../services/answer-display.js';
 import { Debouncer } from '../utils/debouncer.js';
 import { createElement, addClass, removeClass } from '../utils/dom-helpers.js';
 import { emitCustomEvent } from '../utils/event-helpers.js';
-import { getJSON, setJSON } from '../utils/storage-helpers.js';
+import { getJSON, setJSON, INSTRUCTOR_SHOW_ANSWERS_KEY } from '../utils/storage-helpers.js';
 import { STORAGE_KEYS } from '../types/contracts.js';
 import { info, error as logError, warn } from '../utils/logger.js';
 import { getStorageService } from '../services/storage-service.js';
@@ -304,7 +304,7 @@ function enhanceInteractive(table: HTMLTableElement, metadata: QuizTableMetadata
 
   // Check if instructor mode with toggle already enabled
   const isInstructor = sessionStorage.getItem(STORAGE_KEYS.INSTRUCTOR) === 'true';
-  const showAnswers = sessionStorage.getItem('qd/instructor/showAnswers') === 'true';
+  const showAnswers = sessionStorage.getItem(INSTRUCTOR_SHOW_ANSWERS_KEY) === 'true';
   if (isInstructor && showAnswers) {
     void showStudentAnswersForTable(table, metadata);
   }

--- a/src/init/bootstrap.ts
+++ b/src/init/bootstrap.ts
@@ -7,16 +7,12 @@ import { info, warn } from '../utils/logger.js';
 import { EventCoordinator } from './event-coordinator.js';
 import { SessionCoordinator } from './session-coordinator.js';
 import { injectComponents, type ComponentInjectorConfig } from './component-injector.js';
-import {
-  enhanceQuizTable,
-  getQuizTableMetadata,
-  showStudentAnswersForTable,
-  hideStudentAnswersForTable,
-} from '../enhancers/quiz-table.js';
+import { enhanceQuizTable, getQuizTableMetadata } from '../enhancers/quiz-table.js';
+import { revealInstructorAnswers } from '../enhancers/instructor-answer-reveal.js';
 import { enhanceAnalysisTable } from '../enhancers/analysis-table.js';
 import { enhanceHomeBadges } from '../enhancers/home-badges.js';
 import { getStorageService } from '../services/storage-service.js';
-import { getJSON, setJSON, INSTRUCTOR_SHOW_ANSWERS_KEY } from '../utils/storage-helpers.js';
+import { getJSON, setJSON } from '../utils/storage-helpers.js';
 import { getPageIdFromUrl } from '../utils/page-id.js';
 import { STORAGE_KEYS, type SessionData, type SessionCache } from '../types/contracts.js';
 
@@ -330,44 +326,9 @@ function revealQuizAnswersForInstructor(): void {
     // Update metadata with pageId
     metadata.pageId = pageId;
 
-    // Add instructor class for CSS visibility override
-    table.classList.add('qd-quiz-instructor');
-
-    // Remove qd-hidden class from answer column (column 1)
-    const answerCells = table.querySelectorAll('td:nth-child(2), th:nth-child(2)');
-    answerCells.forEach((cell) => {
-      cell.classList.remove('qd-hidden');
-    });
-
-    // Restore answer text to data cells only (not header)
-    const answerDataCells = table.querySelectorAll('tbody td:nth-child(2)');
-    answerDataCells.forEach((cell, index) => {
-      const question = metadata.parsed.questions[index];
-      if (question && cell instanceof HTMLTableCellElement) {
-        cell.textContent = question.correctAnswer;
-      }
-    });
-
-    // Remove qd-hidden class from detail column (column 2)
-    const detailCells = table.querySelectorAll('td:nth-child(3), th:nth-child(3)');
-    detailCells.forEach((cell) => cell.classList.remove('qd-hidden'));
-
-    // Set up instructor toggle event listeners (since table is non-interactive)
-    const showAnswersHandler = () => {
-      void showStudentAnswersForTable(table, metadata);
-    };
-    const hideAnswersHandler = () => {
-      hideStudentAnswersForTable(table);
-    };
-
-    document.addEventListener('qd:instructor-show-answers', showAnswersHandler);
-    document.addEventListener('qd:instructor-hide-answers', hideAnswersHandler);
-
-    // Check if toggle already enabled
-    const showAnswers = sessionStorage.getItem(INSTRUCTOR_SHOW_ANSWERS_KEY) === 'true';
-    if (showAnswers) {
-      void showAnswersHandler();
-    }
+    // Reveal answers + wire instructor toggles via the shared enhancer.
+    // The initial-load path adds the qd-quiz-instructor CSS visibility class.
+    revealInstructorAnswers(table, metadata, { addInstructorClass: true });
   });
 
   info(`Revealed answers for instructor on ${quizTables.length} quiz table(s)`);

--- a/src/init/bootstrap.ts
+++ b/src/init/bootstrap.ts
@@ -16,7 +16,8 @@ import {
 import { enhanceAnalysisTable } from '../enhancers/analysis-table.js';
 import { enhanceHomeBadges } from '../enhancers/home-badges.js';
 import { getStorageService } from '../services/storage-service.js';
-import { getJSON, setJSON } from '../utils/storage-helpers.js';
+import { getJSON, setJSON, INSTRUCTOR_SHOW_ANSWERS_KEY } from '../utils/storage-helpers.js';
+import { getPageIdFromUrl } from '../utils/page-id.js';
 import { STORAGE_KEYS, type SessionData, type SessionCache } from '../types/contracts.js';
 
 /**
@@ -311,10 +312,7 @@ function enhanceHomeBadgesIfPresent(): void {
  * Shows answer and detail columns that were hidden for security
  */
 function revealQuizAnswersForInstructor(): void {
-  // Extract pageId from URL
-  const pathname = window.location.pathname;
-  const filename = pathname.substring(pathname.lastIndexOf('/') + 1);
-  const pageId = filename.replace(/\.html?$/i, '');
+  const pageId = getPageIdFromUrl();
 
   // Reveal answer and detail columns for instructor (they're hidden by default in non-interactive mode)
   const quizTables = document.querySelectorAll<HTMLTableElement>('table.qd-quiz');
@@ -366,7 +364,7 @@ function revealQuizAnswersForInstructor(): void {
     document.addEventListener('qd:instructor-hide-answers', hideAnswersHandler);
 
     // Check if toggle already enabled
-    const showAnswers = sessionStorage.getItem('qd/instructor/showAnswers') === 'true';
+    const showAnswers = sessionStorage.getItem(INSTRUCTOR_SHOW_ANSWERS_KEY) === 'true';
     if (showAnswers) {
       void showAnswersHandler();
     }
@@ -418,10 +416,7 @@ async function checkExistingSessionAndUpgradeTables(): Promise<void> {
     }
   }
 
-  // Extract pageId from URL filename
-  const pathname = window.location.pathname;
-  const filename = pathname.substring(pathname.lastIndexOf('/') + 1);
-  const pageId = filename.replace(/\.html?$/i, '');
+  const pageId = getPageIdFromUrl();
 
   if (!pageId) {
     info('No pageId found, skipping table upgrade');

--- a/src/init/event-coordinator.ts
+++ b/src/init/event-coordinator.ts
@@ -17,7 +17,8 @@ import {
 } from '../enhancers/analysis-table.js';
 import { getStorageService } from '../services/storage-service.js';
 import { STORAGE_KEYS } from '../types/contracts.js';
-import { setJSON, getJSON } from '../utils/storage-helpers.js';
+import { setJSON, getJSON, INSTRUCTOR_SHOW_ANSWERS_KEY } from '../utils/storage-helpers.js';
+import { getPageIdFromUrl } from '../utils/page-id.js';
 import type { SessionData, SessionCache } from '../types/contracts.js';
 
 /**
@@ -135,10 +136,7 @@ export class EventCoordinator {
    * Upgrade all tables to interactive mode after login
    */
   private upgradeTablesAfterLogin(): void {
-    // Extract pageId from URL filename
-    const pathname = window.location.pathname;
-    const filename = pathname.substring(pathname.lastIndexOf('/') + 1);
-    const pageId = filename.replace(/\.html?$/i, '');
+    const pageId = getPageIdFromUrl();
 
     if (!pageId) {
       info('No pageId found, skipping table upgrade to interactive mode');
@@ -193,7 +191,7 @@ export class EventCoordinator {
         document.addEventListener('qd:instructor-hide-answers', hideAnswersHandler);
 
         // Check if toggle already enabled
-        const showAnswers = sessionStorage.getItem('qd/instructor/showAnswers') === 'true';
+        const showAnswers = sessionStorage.getItem(INSTRUCTOR_SHOW_ANSWERS_KEY) === 'true';
         if (showAnswers) {
           void showAnswersHandler();
         }

--- a/src/init/event-coordinator.ts
+++ b/src/init/event-coordinator.ts
@@ -8,16 +8,15 @@ import {
   enhanceQuizTable,
   getQuizTableMetadata,
   resetQuizTableToNonInteractive,
-  showStudentAnswersForTable,
-  hideStudentAnswersForTable,
 } from '../enhancers/quiz-table.js';
+import { revealInstructorAnswers } from '../enhancers/instructor-answer-reveal.js';
 import {
   enhanceAnalysisTable,
   resetAnalysisTableToNonInteractive,
 } from '../enhancers/analysis-table.js';
 import { getStorageService } from '../services/storage-service.js';
 import { STORAGE_KEYS } from '../types/contracts.js';
-import { setJSON, getJSON, INSTRUCTOR_SHOW_ANSWERS_KEY } from '../utils/storage-helpers.js';
+import { setJSON, getJSON } from '../utils/storage-helpers.js';
 import { getPageIdFromUrl } from '../utils/page-id.js';
 import type { SessionData, SessionCache } from '../types/contracts.js';
 
@@ -160,41 +159,9 @@ export class EventCoordinator {
         // Update metadata with pageId for instructor toggle
         metadata.pageId = pageId;
 
-        // Remove qd-hidden class from answer column (column 1)
-        const answerCells = table.querySelectorAll('td:nth-child(2), th:nth-child(2)');
-        answerCells.forEach((cell) => {
-          cell.classList.remove('qd-hidden');
-        });
-
-        // Restore answer text to data cells only (not header)
-        const answerDataCells = table.querySelectorAll('tbody td:nth-child(2)');
-        answerDataCells.forEach((cell, index) => {
-          const question = metadata.parsed.questions[index];
-          if (question && cell instanceof HTMLTableCellElement) {
-            cell.textContent = question.correctAnswer;
-          }
-        });
-
-        // Remove qd-hidden class from detail column (column 2)
-        const detailCells = table.querySelectorAll('td:nth-child(3), th:nth-child(3)');
-        detailCells.forEach((cell) => cell.classList.remove('qd-hidden'));
-
-        // Set up instructor toggle event listeners (since table is non-interactive)
-        const showAnswersHandler = () => {
-          void showStudentAnswersForTable(table, metadata);
-        };
-        const hideAnswersHandler = () => {
-          hideStudentAnswersForTable(table);
-        };
-
-        document.addEventListener('qd:instructor-show-answers', showAnswersHandler);
-        document.addEventListener('qd:instructor-hide-answers', hideAnswersHandler);
-
-        // Check if toggle already enabled
-        const showAnswers = sessionStorage.getItem(INSTRUCTOR_SHOW_ANSWERS_KEY) === 'true';
-        if (showAnswers) {
-          void showAnswersHandler();
-        }
+        // Reveal answers + wire instructor toggles via the shared enhancer.
+        // The post-login path does not add the qd-quiz-instructor class.
+        revealInstructorAnswers(table, metadata);
       });
       return;
     }

--- a/src/services/auth/instructor-auth.ts
+++ b/src/services/auth/instructor-auth.ts
@@ -1,0 +1,57 @@
+/**
+ * Instructor password authentication.
+ *
+ * The single source of instructor-password hashing/verification. Previously the
+ * SHA-256 + 12-char-truncation logic was duplicated verbatim in `qd-login.ts`
+ * (`hashPassword`/`getExpectedHash`) and `qd-migration-dialog.ts`
+ * (`validatePassword`). Both components now consume this module.
+ *
+ * The 12-character truncation keeps hashes short enough to paste into
+ * author-friendly Oxygen configuration dialogs.
+ */
+
+import { CONFIG_IDS } from '../../config/dom-config-reader.js';
+
+/**
+ * Hash a plaintext instructor password.
+ *
+ * @param plain - Plaintext password
+ * @returns SHA-256 hex digest truncated to the first 12 characters
+ */
+export async function hashPassword(plain: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(plain);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  // Return first 12 characters for author-friendly Oxygen dialogs
+  return hashArray
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .substring(0, 12);
+}
+
+/**
+ * Read the configured instructor-password hash from the hidden config element.
+ *
+ * @returns The trimmed configured hash, or an empty string when not configured
+ */
+export function getExpectedInstructorHash(): string {
+  const hashElement = document.getElementById(CONFIG_IDS.instructorHash);
+  return hashElement?.textContent?.trim() || '';
+}
+
+/**
+ * Verify a plaintext password against the configured instructor hash.
+ *
+ * @param plain - Plaintext password to check
+ * @returns true when the password matches the configured hash; false when it
+ *   does not match or when no instructor hash is configured
+ */
+export async function verifyInstructorPassword(plain: string): Promise<boolean> {
+  const expectedHash = getExpectedInstructorHash();
+  if (!expectedHash) {
+    return false;
+  }
+  const actualHash = await hashPassword(plain);
+  return actualHash === expectedHash;
+}

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -17,6 +17,7 @@ import type {
 } from '../types/contracts.js';
 import { STORAGE_KEYS, SESSION_TIMEOUT_MS } from '../types/contracts.js';
 import { info, warn, error } from '../utils/logger.js';
+import { INSTRUCTOR_SHOW_ANSWERS_KEY } from '../utils/storage-helpers.js';
 import { isSessionExpired } from '../utils/calculation-helpers.js';
 
 /**
@@ -122,7 +123,7 @@ export class SessionService {
     sessionStorage.removeItem(STORAGE_KEYS.INSTRUCTOR);
 
     // Clear instructor-specific state (FR-001)
-    sessionStorage.removeItem('qd/instructor/showAnswers');
+    sessionStorage.removeItem(INSTRUCTOR_SHOW_ANSWERS_KEY);
 
     if (session) {
       info(`Session cleared for ${session.serviceId}`);

--- a/src/services/storage-service.ts
+++ b/src/services/storage-service.ts
@@ -21,6 +21,30 @@ import { recalculateTotalsFromPages } from '../utils/calculation-helpers.js';
 import { info, warn, error as logError } from '../utils/logger.js';
 
 /**
+ * Build a fresh, empty student record for a session.
+ *
+ * Used when no persisted record exists yet (first login) or when IndexedDB
+ * cannot be read. Centralizes the record shape so the two creation paths in
+ * {@link StorageService.loadStudentRecord} stay identical.
+ *
+ * @param session - Current session data
+ * @returns A new, empty student record
+ */
+export function createEmptyStudentRecord(session: SessionData): StudentRecord {
+  return {
+    schema: 1,
+    docId: session.release, // Use release as docId
+    release: session.release,
+    serviceId: session.serviceId,
+    name: session.name,
+    attempted: 0,
+    correct: 0,
+    updated: new Date().toISOString(),
+    pages: {},
+  };
+}
+
+/**
  * Storage Service for managing student records
  */
 export class StorageService {
@@ -71,35 +95,14 @@ export class StorageService {
       }
 
       // Create new student record
-      const newRecord: StudentRecord = {
-        schema: 1,
-        docId: session.release, // Use release as docId
-        release: session.release,
-        serviceId: session.serviceId,
-        name: session.name,
-        attempted: 0,
-        correct: 0,
-        updated: new Date().toISOString(),
-        pages: {},
-      };
+      const newRecord = createEmptyStudentRecord(session);
 
       info(`Created new student record for ${session.serviceId}`);
       return newRecord;
     } catch (err) {
       // If IndexedDB has schema issues, create a new record
       warn(`IndexedDB error, creating new record: ${(err as Error).message}`);
-      const newRecord: StudentRecord = {
-        schema: 1,
-        docId: session.release,
-        release: session.release,
-        serviceId: session.serviceId,
-        name: session.name,
-        attempted: 0,
-        correct: 0,
-        updated: new Date().toISOString(),
-        pages: {},
-      };
-      return newRecord;
+      return createEmptyStudentRecord(session);
     }
   }
 

--- a/src/utils/page-id.ts
+++ b/src/utils/page-id.ts
@@ -1,0 +1,32 @@
+/**
+ * Page ID extraction utility
+ *
+ * Derives the `PageId` for the current document from a URL by taking the final
+ * path segment (the filename) and stripping its `.html`/`.htm` extension.
+ * Consolidates the inline pathname→filename→strip-extension parses previously
+ * duplicated across `bootstrap.ts` and `event-coordinator.ts`.
+ */
+
+import type { PageId } from '../types/contracts.js';
+
+/**
+ * Extract the page ID from a URL.
+ *
+ * @param url - Optional URL or path to parse. When omitted, the current
+ *   document's `window.location.pathname` is used (preserving the original
+ *   inline behavior). Query strings and hash fragments are ignored.
+ * @returns The filename without its `.html`/`.htm` extension. Returns an empty
+ *   string when the URL ends in a trailing slash (no filename).
+ *
+ * @example
+ * getPageIdFromUrl('/training/gram-1.html'); // 'gram-1'
+ * getPageIdFromUrl('quiz-index.html?x=1#top'); // 'quiz-index'
+ */
+export function getPageIdFromUrl(url?: string): PageId {
+  // Strip query string and hash fragment, then isolate the path portion.
+  // window.location.pathname never contains '?' or '#', so this is a no-op for
+  // the default (current-document) case and preserves the original behavior.
+  const path = (url ?? window.location.pathname).split(/[?#]/)[0] ?? '';
+  const filename = path.substring(path.lastIndexOf('/') + 1);
+  return filename.replace(/\.html?$/i, '');
+}

--- a/src/utils/storage-helpers.ts
+++ b/src/utils/storage-helpers.ts
@@ -9,6 +9,16 @@
 import { warn } from './logger.js';
 
 /**
+ * sessionStorage key for the instructor "show student answers" overlay toggle.
+ *
+ * Tracks whether the instructor answer overlay is active for the current
+ * session. Previously inlined as the magic string `'qd/instructor/showAnswers'`
+ * across multiple modules. Not part of the frozen STORAGE_KEYS contract in
+ * `src/types/contracts.ts`.
+ */
+export const INSTRUCTOR_SHOW_ANSWERS_KEY = 'qd/instructor/showAnswers';
+
+/**
  * Get and parse JSON data from sessionStorage
  *
  * @param key - Storage key

--- a/tests/integration/instructor-answer-reveal.test.ts
+++ b/tests/integration/instructor-answer-reveal.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Characterization tests for the shared instructor answer-reveal enhancer (T014).
+ *
+ * Captures the behavior previously duplicated across bootstrap.ts (initial-load
+ * path, which adds the instructor class) and event-coordinator.ts (post-login
+ * path, which does not): answer/detail columns unhidden and correct answers
+ * re-injected into the DOM.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  revealInstructorAnswers,
+  hideInstructorAnswers,
+} from '../../src/enhancers/instructor-answer-reveal.js';
+import {
+  enhanceQuizTable,
+  getQuizTableMetadata,
+  type QuizTableMetadata,
+} from '../../src/enhancers/quiz-table.js';
+import type { SessionData, StudentRecord } from '../../src/types/contracts.js';
+import { STORAGE_KEYS } from '../../src/types/contracts.js';
+import { INSTRUCTOR_SHOW_ANSWERS_KEY } from '../../src/utils/storage-helpers.js';
+import { getStorageService, resetStorageService } from '../../src/services/storage-service.js';
+import { resetStorageAdapter } from '../../src/services/storage/indexeddb.js';
+
+const TEST_DB_NAME = 'BrowserTestDB';
+const RELEASE = '11-2024';
+const PAGE_ID = 'quiz-mcq';
+
+function createMCQTable(): HTMLTableElement {
+  const table = document.createElement('table');
+  table.className = 'qd-quiz';
+  table.innerHTML = `
+    <thead><tr><th>Question</th><th>Answer</th><th>Detail</th></tr></thead>
+    <tbody>
+      <tr><td>What is 2 + 2?</td><td>1</td><td><ol><li>4</li><li>5</li></ol></td></tr>
+      <tr><td>What is 3 + 3?</td><td>2</td><td><ol><li>5</li><li>6</li></ol></td></tr>
+    </tbody>
+  `;
+  return table;
+}
+
+function enhanceWithMetadata(table: HTMLTableElement): QuizTableMetadata {
+  enhanceQuizTable(table, { interactive: false });
+  const metadata = getQuizTableMetadata(table);
+  if (!metadata) throw new Error('expected quiz metadata');
+  metadata.pageId = PAGE_ID;
+  return metadata;
+}
+
+describe('revealInstructorAnswers', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    container.remove();
+    sessionStorage.clear();
+    resetStorageService();
+    resetStorageAdapter();
+  });
+
+  it('unhides the answer and detail columns', () => {
+    const table = createMCQTable();
+    container.appendChild(table);
+    const metadata = enhanceWithMetadata(table);
+
+    // Enhancement hid columns 2 and 3
+    const headerCells = table.querySelectorAll('thead th');
+    expect(headerCells[1]?.classList.contains('qd-hidden')).toBe(true);
+    expect(headerCells[2]?.classList.contains('qd-hidden')).toBe(true);
+
+    revealInstructorAnswers(table, metadata);
+
+    table.querySelectorAll('td:nth-child(2), th:nth-child(2)').forEach((cell) => {
+      expect(cell.classList.contains('qd-hidden')).toBe(false);
+    });
+    table.querySelectorAll('td:nth-child(3), th:nth-child(3)').forEach((cell) => {
+      expect(cell.classList.contains('qd-hidden')).toBe(false);
+    });
+  });
+
+  it('re-injects the correct answers into the data cells', () => {
+    const table = createMCQTable();
+    container.appendChild(table);
+    const metadata = enhanceWithMetadata(table);
+
+    revealInstructorAnswers(table, metadata);
+
+    const answerCells = table.querySelectorAll('tbody td:nth-child(2)');
+    expect(answerCells[0]?.textContent).toBe(metadata.parsed.questions[0]?.correctAnswer);
+    expect(answerCells[1]?.textContent).toBe(metadata.parsed.questions[1]?.correctAnswer);
+  });
+
+  it('adds the qd-quiz-instructor class only when requested (initial-load path)', () => {
+    const table = createMCQTable();
+    container.appendChild(table);
+    const metadata = enhanceWithMetadata(table);
+
+    revealInstructorAnswers(table, metadata, { addInstructorClass: true });
+    expect(table.classList.contains('qd-quiz-instructor')).toBe(true);
+  });
+
+  it('does not add the qd-quiz-instructor class by default (post-login path)', () => {
+    const table = createMCQTable();
+    container.appendChild(table);
+    const metadata = enhanceWithMetadata(table);
+
+    revealInstructorAnswers(table, metadata);
+    expect(table.classList.contains('qd-quiz-instructor')).toBe(false);
+  });
+
+  it('shows the overlay immediately when the toggle is already enabled', async () => {
+    sessionStorage.setItem(INSTRUCTOR_SHOW_ANSWERS_KEY, 'true');
+
+    const session: SessionData = {
+      serviceId: 'INSTRUCTOR',
+      name: 'Instructor',
+      release: RELEASE,
+      loginTime: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+      instructorUnlocked: true,
+    };
+    sessionStorage.setItem(STORAGE_KEYS.SESSION, JSON.stringify(session));
+
+    const storageService = getStorageService(TEST_DB_NAME);
+    await storageService.init();
+    const student: StudentRecord = {
+      schema: 1,
+      docId: RELEASE,
+      release: RELEASE,
+      serviceId: 'RN2344',
+      name: 'Alice',
+      attempted: 1,
+      correct: 1,
+      updated: new Date().toISOString(),
+      pages: {
+        [PAGE_ID]: {
+          state: 'complete',
+          answers: [{ answer: '1', success: true, timestamp: '2024-11-01T09:30:00.000Z' }],
+        },
+      },
+    };
+    await storageService.saveStudentRecord(student);
+
+    const table = createMCQTable();
+    container.appendChild(table);
+    const metadata = enhanceWithMetadata(table);
+
+    revealInstructorAnswers(table, metadata);
+
+    // Allow the async overlay render to settle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(table.querySelectorAll('.qd-student-answers').length).toBeGreaterThan(0);
+
+    hideInstructorAnswers(table);
+    expect(table.querySelectorAll('.qd-student-answers').length).toBe(0);
+  });
+});

--- a/tests/integration/quiz-instructor-overlay.test.ts
+++ b/tests/integration/quiz-instructor-overlay.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Integration tests for the quiz instructor answer overlay.
+ *
+ * T012: Characterization of the current rendered student-answer overlay
+ *       (structure + content) — the baseline the XSS fix must preserve.
+ * T013: XSS regression — student-supplied name/answer containing HTML must
+ *       render as literal text, never as live markup (FR-004, SC-003).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  enhanceQuizTable,
+  getQuizTableMetadata,
+  showStudentAnswersForTable,
+  hideStudentAnswersForTable,
+} from '../../src/enhancers/quiz-table.js';
+import type { SessionData, StudentRecord } from '../../src/types/contracts.js';
+
+type QuizMetadata = NonNullable<ReturnType<typeof getQuizTableMetadata>>;
+import { STORAGE_KEYS } from '../../src/types/contracts.js';
+import { getStorageService, resetStorageService } from '../../src/services/storage-service.js';
+import { resetStorageAdapter } from '../../src/services/storage/indexeddb.js';
+
+const TEST_DB_NAME = 'BrowserTestDB';
+const RELEASE = '11-2024';
+const PAGE_ID = 'quiz-mcq';
+
+function createMCQTable(): HTMLTableElement {
+  const table = document.createElement('table');
+  table.className = 'qd-quiz';
+  table.innerHTML = `
+    <thead>
+      <tr><th>Question</th><th>Answer</th><th>Detail</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>What is 2 + 2?</td>
+        <td>1</td>
+        <td><ol><li>4</li><li>5</li><li>6</li></ol></td>
+      </tr>
+    </tbody>
+  `;
+  return table;
+}
+
+function makeStudent(
+  name: string,
+  serviceId: string,
+  answer: string,
+  success: boolean,
+): StudentRecord {
+  return {
+    schema: 1,
+    docId: RELEASE,
+    release: RELEASE,
+    serviceId,
+    name,
+    attempted: 1,
+    correct: success ? 1 : 0,
+    updated: new Date().toISOString(),
+    pages: {
+      [PAGE_ID]: {
+        state: success ? 'complete' : 'incomplete',
+        answers: [{ answer, success, timestamp: '2024-11-01T09:30:00.000Z' }],
+      },
+    },
+  };
+}
+
+/** Enhance the table and return metadata wired with the page id under test. */
+function enhanceWithMetadata(table: HTMLTableElement): QuizMetadata {
+  enhanceQuizTable(table, { interactive: false });
+  const metadata = getQuizTableMetadata(table);
+  if (!metadata) throw new Error('expected quiz metadata');
+  metadata.pageId = PAGE_ID;
+  return metadata;
+}
+
+describe('Quiz instructor answer overlay', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    sessionStorage.clear();
+
+    const session: SessionData = {
+      serviceId: 'INSTRUCTOR',
+      name: 'Instructor',
+      release: RELEASE,
+      loginTime: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+      instructorUnlocked: true,
+    };
+    sessionStorage.setItem(STORAGE_KEYS.SESSION, JSON.stringify(session));
+
+    const storageService = getStorageService(TEST_DB_NAME);
+    await storageService.init();
+  });
+
+  afterEach(() => {
+    container.remove();
+    sessionStorage.clear();
+    resetStorageService();
+    resetStorageAdapter();
+  });
+
+  it('renders a student-answer overlay with name, masked id, answer and timestamp (T012)', async () => {
+    const storageService = getStorageService();
+    await storageService.saveStudentRecord(makeStudent('Alice Smith', 'RN2344', '1', true));
+    await storageService.saveStudentRecord(makeStudent('Bob Jones', 'RN9876', '2', false));
+
+    const table = createMCQTable();
+    container.appendChild(table);
+    const metadata = enhanceWithMetadata(table);
+
+    await showStudentAnswersForTable(table, metadata);
+
+    const answerCell = table.querySelector('tbody tr:first-child td:nth-child(2)');
+    const overlay = answerCell?.querySelector('.qd-student-answers');
+    expect(overlay).toBeTruthy();
+
+    const entries = overlay?.querySelectorAll('.qd-student-answer');
+    expect(entries?.length).toBe(2);
+
+    // Correct/incorrect css classes preserved
+    expect(entries?.[0]?.classList.contains('qd-correct')).toBe(true);
+    expect(entries?.[1]?.classList.contains('qd-incorrect')).toBe(true);
+
+    // Structural spans + content
+    const first = entries?.[0];
+    expect(first?.querySelector('.qd-student-name')?.textContent).toContain('Alice Smith');
+    expect(first?.querySelector('.qd-student-name')?.textContent).toContain('2344');
+    expect(first?.querySelector('.qd-student-answer-text')?.textContent).toBe('1');
+    expect(first?.querySelector('.qd-timestamp')?.textContent?.trim()).toBeTruthy();
+  });
+
+  it('removes the overlay on hide', async () => {
+    const storageService = getStorageService();
+    await storageService.saveStudentRecord(makeStudent('Alice Smith', 'RN2344', '1', true));
+
+    const table = createMCQTable();
+    container.appendChild(table);
+    const metadata = enhanceWithMetadata(table);
+
+    await showStudentAnswersForTable(table, metadata);
+    expect(table.querySelectorAll('.qd-student-answers').length).toBe(1);
+
+    hideStudentAnswersForTable(table);
+    expect(table.querySelectorAll('.qd-student-answers').length).toBe(0);
+  });
+
+  it('renders student-supplied markup as inert text, not live HTML (T013, XSS)', async () => {
+    const storageService = getStorageService();
+    const maliciousName = '<img src=x onerror="window.__xss=1">Mallory';
+    const maliciousAnswer = '<script>window.__xss=1</script>';
+    await storageService.saveStudentRecord(
+      makeStudent(maliciousName, 'RN0001', maliciousAnswer, false),
+    );
+
+    const table = createMCQTable();
+    container.appendChild(table);
+    const metadata = enhanceWithMetadata(table);
+
+    await showStudentAnswersForTable(table, metadata);
+
+    const overlay = table.querySelector('.qd-student-answers');
+    expect(overlay).toBeTruthy();
+
+    // No live elements were created from the student-controlled strings.
+    expect(overlay?.querySelector('img')).toBeNull();
+    expect(overlay?.querySelector('script')).toBeNull();
+
+    // The raw markup survives verbatim as text content.
+    const nameSpan = overlay?.querySelector('.qd-student-name');
+    const answerSpan = overlay?.querySelector('.qd-student-answer-text');
+    expect(nameSpan?.textContent).toContain(maliciousName);
+    expect(answerSpan?.textContent).toBe(maliciousAnswer);
+  });
+});

--- a/tests/unit/instructor-auth.test.ts
+++ b/tests/unit/instructor-auth.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for shared instructor-password authentication (T016).
+ *
+ * Covers SHA-256 + 12-char-truncation hashing and verification against the
+ * configured hash element (FR-008).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  hashPassword,
+  getExpectedInstructorHash,
+  verifyInstructorPassword,
+} from '../../src/services/auth/instructor-auth.js';
+import { CONFIG_IDS } from '../../src/config/dom-config-reader.js';
+
+function setConfiguredHash(value: string | null): void {
+  const existing = document.getElementById(CONFIG_IDS.instructorHash);
+  existing?.remove();
+  if (value === null) return;
+  const span = document.createElement('span');
+  span.id = CONFIG_IDS.instructorHash;
+  span.textContent = value;
+  document.body.appendChild(span);
+}
+
+describe('instructor-auth', () => {
+  afterEach(() => {
+    setConfiguredHash(null);
+  });
+
+  describe('hashPassword', () => {
+    it('returns a 12-character hex digest', async () => {
+      const hash = await hashPassword('secret');
+      expect(hash).toMatch(/^[0-9a-f]{12}$/);
+    });
+
+    it('is deterministic for the same input', async () => {
+      expect(await hashPassword('secret')).toBe(await hashPassword('secret'));
+    });
+
+    it('differs for different inputs', async () => {
+      expect(await hashPassword('secret')).not.toBe(await hashPassword('other'));
+    });
+
+    it('matches the first 12 chars of the full SHA-256 of "secret"', async () => {
+      // Known SHA-256("secret") = 2bb80d537b1da3e3...
+      expect(await hashPassword('secret')).toBe('2bb80d537b1d');
+    });
+  });
+
+  describe('getExpectedInstructorHash', () => {
+    it('returns the trimmed configured hash', () => {
+      setConfiguredHash('  abc123def456  ');
+      expect(getExpectedInstructorHash()).toBe('abc123def456');
+    });
+
+    it('returns empty string when the element is missing', () => {
+      setConfiguredHash(null);
+      expect(getExpectedInstructorHash()).toBe('');
+    });
+  });
+
+  describe('verifyInstructorPassword', () => {
+    beforeEach(() => {
+      setConfiguredHash(null);
+    });
+
+    it('returns true when the password matches the configured hash', async () => {
+      setConfiguredHash(await hashPassword('letmein'));
+      expect(await verifyInstructorPassword('letmein')).toBe(true);
+    });
+
+    it('returns false when the password does not match', async () => {
+      setConfiguredHash(await hashPassword('letmein'));
+      expect(await verifyInstructorPassword('wrong')).toBe(false);
+    });
+
+    it('returns false when no hash is configured', async () => {
+      setConfiguredHash(null);
+      expect(await verifyInstructorPassword('anything')).toBe(false);
+    });
+  });
+});

--- a/tests/unit/utils/page-id.test.ts
+++ b/tests/unit/utils/page-id.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for page-id extraction utility
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getPageIdFromUrl } from '../../../src/utils/page-id.js';
+
+describe('getPageIdFromUrl', () => {
+  it('extracts the page id from a root-level filename', () => {
+    expect(getPageIdFromUrl('/quiz-index.html')).toBe('quiz-index');
+  });
+
+  it('extracts the page id from a nested path', () => {
+    expect(getPageIdFromUrl('/training/topics/gram-1.html')).toBe('gram-1');
+  });
+
+  it('ignores a query string', () => {
+    expect(getPageIdFromUrl('/topics/gram-1.html?attempt=2')).toBe('gram-1');
+  });
+
+  it('ignores a hash fragment', () => {
+    expect(getPageIdFromUrl('/topics/gram-1.html#question-3')).toBe('gram-1');
+  });
+
+  it('ignores both query string and hash fragment', () => {
+    expect(getPageIdFromUrl('gram-1.html?x=1#top')).toBe('gram-1');
+  });
+
+  it('strips a .htm extension as well as .html', () => {
+    expect(getPageIdFromUrl('/legacy/gram-1.htm')).toBe('gram-1');
+  });
+
+  it('returns the filename unchanged when there is no .html extension', () => {
+    expect(getPageIdFromUrl('/topics/gram-1')).toBe('gram-1');
+  });
+
+  it('returns an empty string for a trailing-slash path', () => {
+    expect(getPageIdFromUrl('/topics/')).toBe('');
+  });
+
+  it('handles a bare filename with no leading slash', () => {
+    expect(getPageIdFromUrl('analysis-examples.html')).toBe('analysis-examples');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the first, independently-shippable slices of feature **012-code-review** (`/speckit.implement 12`) — Phases 1–3 in full and the high-value security/duplication work of Phase 4 (US2). Every slice is behavior-preserving (the one sanctioned exception being the quiz-overlay XSS fix) and gated by the full Definition of Done.

The work follows the spec's own incremental-delivery strategy (SC-006): each commit is green and mergeable on its own.

## What's included

### Phase 1 — Baseline (T001–T002)
- Recorded the regression budget in `quickstart.md`: 782 unit + 67 integration tests; **36.71 KB gzip** bundle (limit 40 KB); the 8 files >400 lines.

### Phase 2 — Foundational consolidation (T003–T008, no behavior change)
- `INSTRUCTOR_SHOW_ANSWERS_KEY` constant replaces the `'qd/instructor/showAnswers'` magic string in 5 modules.
- New `utils/page-id.ts` `getPageIdFromUrl()` replaces 3 inline pathname→filename→strip-`.html` parses (with unit tests).
- `clearBadges(link)` helper replaces 3 duplicated badge-stripping loops.
- `createEmptyStudentRecord(session)` replaces the two duplicated new-record literals.
- `spinnerStyles` extracted into `components/shared-styles.ts` (adopted by the migration dialog).

### Phase 3 — Maintainer report verified (T009–T011)
- Confirmed `code-review-report.md` lists every `src/**` file >400 lines with line count/severity/decomposition, addresses all five hot-spot criteria with file/line refs, and provides a lowest-risk→highest-payoff sequence. Reconciled against the T002 baseline.

### Phase 4 — Security & duplication (US2, partial)
- **🔒 Quiz instructor-overlay XSS fix (FR-004):** student-supplied name/answer now rendered via `textContent`/element construction instead of `innerHTML`, so injected HTML is inert text. Characterization + XSS-regression integration tests added (T012/T013/T020).
- **Single shared answer-reveal** (`enhancers/instructor-answer-reveal.ts`): both `bootstrap.ts` (initial-load) and `event-coordinator.ts` (post-login) now call one function; behavior preserved exactly via an `addInstructorClass` option. Characterization tests added (T014/T019).
- **Shared `instructor-auth`** (`services/auth/instructor-auth.ts`): one SHA-256 + 12-char hashing implementation, consumed by both `qd-login` and `qd-migration-dialog`; duplicated crypto deleted; instructor-hash config reads routed through it (T016/T017, partial T018).

## Verification
Final Definition of Done — all green:
- `typecheck`, `lint`, `format:check` clean
- **800 unit + 75 integration tests** passing
- `build` OK; bundle **36.94 KB gzip** (within the 40 KB budget, no regression)

## Deferred to follow-up
The remaining tasks are large and security-sensitive; rushing them would risk the behavior regressions the spec's golden rule guards against. They are best delivered as further independent slices:
- **T021 / T015 / remainder of T018** — `AuthService` extraction collapsing the ~100-line `handleStudentLogin`/`retryLoginAfterMigration` duplicate and routing the remaining dbName/title config reads (these are entangled with custom error semantics, so they belong with the AuthService move).
- **US3 (T022–T043)** — decompose the six oversized modules (`indexeddb.ts`, `quiz-table.ts`, `analysis-table.ts`, `bootstrap.ts`, `session.ts`, `qd-login.ts`) below ~400 lines.
- **US4 (T044–T050)** — reusable Lit components (note: only ~3 KB of gzip headroom remains).
- **Polish (T051–T056)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016tK4JXdkC4s9rYYywjYNiv)_